### PR TITLE
Feature: Add sops to non-bare variants

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -140,12 +140,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-2-0-preview-9-alpine-3-11-20210819-git:
+  build-7-2-0-preview-9-alpine-3-11-20210819-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.2.0-preview.9-alpine-3.11-20210819-git
-      # VARIANT_TAG_WITH_REF: 7.2.0-preview.9-alpine-3.11-20210819-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.2.0-preview.9-alpine-3.11-20210819-git
+      VARIANT_TAG: 7.2.0-preview.9-alpine-3.11-20210819-git-sops
+      # VARIANT_TAG_WITH_REF: 7.2.0-preview.9-alpine-3.11-20210819-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.2.0-preview.9-alpine-3.11-20210819-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -400,12 +400,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-4-alpine-3-11-20210819-git:
+  build-7-1-4-alpine-3-11-20210819-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.4-alpine-3.11-20210819-git
-      # VARIANT_TAG_WITH_REF: 7.1.4-alpine-3.11-20210819-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.1.4-alpine-3.11-20210819-git
+      VARIANT_TAG: 7.1.4-alpine-3.11-20210819-git-sops
+      # VARIANT_TAG_WITH_REF: 7.1.4-alpine-3.11-20210819-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.1.4-alpine-3.11-20210819-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -660,12 +660,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-0-3-alpine-3-9-20200928-git:
+  build-7-0-3-alpine-3-9-20200928-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.0.3-alpine-3.9-20200928-git
-      # VARIANT_TAG_WITH_REF: 7.0.3-alpine-3.9-20200928-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.0.3-alpine-3.9-20200928-git
+      VARIANT_TAG: 7.0.3-alpine-3.9-20200928-git-sops
+      # VARIANT_TAG_WITH_REF: 7.0.3-alpine-3.9-20200928-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.0.3-alpine-3.9-20200928-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -920,12 +920,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-6-2-4-alpine-3-8-git:
+  build-6-2-4-alpine-3-8-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 6.2.4-alpine-3.8-git
-      # VARIANT_TAG_WITH_REF: 6.2.4-alpine-3.8-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/6.2.4-alpine-3.8-git
+      VARIANT_TAG: 6.2.4-alpine-3.8-git-sops
+      # VARIANT_TAG_WITH_REF: 6.2.4-alpine-3.8-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/6.2.4-alpine-3.8-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1180,12 +1180,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-6-1-3-alpine-3-8-git:
+  build-6-1-3-alpine-3-8-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 6.1.3-alpine-3.8-git
-      # VARIANT_TAG_WITH_REF: 6.1.3-alpine-3.8-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/6.1.3-alpine-3.8-git
+      VARIANT_TAG: 6.1.3-alpine-3.8-git-sops
+      # VARIANT_TAG_WITH_REF: 6.1.3-alpine-3.8-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/6.1.3-alpine-3.8-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1440,12 +1440,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-2-0-preview-9-ubuntu-18-04-20210819-git:
+  build-7-2-0-preview-9-ubuntu-18-04-20210819-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.2.0-preview.9-ubuntu-18.04-20210819-git
-      # VARIANT_TAG_WITH_REF: 7.2.0-preview.9-ubuntu-18.04-20210819-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.2.0-preview.9-ubuntu-18.04-20210819-git
+      VARIANT_TAG: 7.2.0-preview.9-ubuntu-18.04-20210819-git-sops
+      # VARIANT_TAG_WITH_REF: 7.2.0-preview.9-ubuntu-18.04-20210819-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.2.0-preview.9-ubuntu-18.04-20210819-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1700,12 +1700,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-4-ubuntu-18-04-20210819-git:
+  build-7-1-4-ubuntu-18-04-20210819-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.4-ubuntu-18.04-20210819-git
-      # VARIANT_TAG_WITH_REF: 7.1.4-ubuntu-18.04-20210819-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.1.4-ubuntu-18.04-20210819-git
+      VARIANT_TAG: 7.1.4-ubuntu-18.04-20210819-git-sops
+      # VARIANT_TAG_WITH_REF: 7.1.4-ubuntu-18.04-20210819-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.1.4-ubuntu-18.04-20210819-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1961,12 +1961,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-0-3-ubuntu-18-04-20201027-git:
+  build-7-0-3-ubuntu-18-04-20201027-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.0.3-ubuntu-18.04-20201027-git
-      # VARIANT_TAG_WITH_REF: 7.0.3-ubuntu-18.04-20201027-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/7.0.3-ubuntu-18.04-20201027-git
+      VARIANT_TAG: 7.0.3-ubuntu-18.04-20201027-git-sops
+      # VARIANT_TAG_WITH_REF: 7.0.3-ubuntu-18.04-20201027-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/7.0.3-ubuntu-18.04-20201027-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2221,12 +2221,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-6-2-4-ubuntu-18-04-git:
+  build-6-2-4-ubuntu-18-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 6.2.4-ubuntu-18.04-git
-      # VARIANT_TAG_WITH_REF: 6.2.4-ubuntu-18.04-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/6.2.4-ubuntu-18.04-git
+      VARIANT_TAG: 6.2.4-ubuntu-18.04-git-sops
+      # VARIANT_TAG_WITH_REF: 6.2.4-ubuntu-18.04-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/6.2.4-ubuntu-18.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2481,12 +2481,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-6-1-3-ubuntu-18-04-git:
+  build-6-1-3-ubuntu-18-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 6.1.3-ubuntu-18.04-git
-      # VARIANT_TAG_WITH_REF: 6.1.3-ubuntu-18.04-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/6.1.3-ubuntu-18.04-git
+      VARIANT_TAG: 6.1.3-ubuntu-18.04-git-sops
+      # VARIANT_TAG_WITH_REF: 6.1.3-ubuntu-18.04-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/6.1.3-ubuntu-18.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2741,12 +2741,12 @@ jobs:
       run: docker logout
       if: always()
 
-  build-6-0-2-ubuntu-16-04-git:
+  build-6-0-2-ubuntu-16-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 6.0.2-ubuntu-16.04-git
-      # VARIANT_TAG_WITH_REF: 6.0.2-ubuntu-16.04-git-${GITHUB_REF}
-      VARIANT_BUILD_DIR: variants/6.0.2-ubuntu-16.04-git
+      VARIANT_TAG: 6.0.2-ubuntu-16.04-git-sops
+      # VARIANT_TAG_WITH_REF: 6.0.2-ubuntu-16.04-git-sops-${GITHUB_REF}
+      VARIANT_BUILD_DIR: variants/6.0.2-ubuntu-16.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -2873,7 +2873,7 @@ jobs:
 
   # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
   converge-master-and-release-branches:
-    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git]
+    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git-sops, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git-sops, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
@@ -2923,7 +2923,7 @@ jobs:
         run: echo ${{ steps.resolve-release-tag.outputs.TAG }}
 
   update-draft-release:
-    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git, resolve-release-tag]
+    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git-sops, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git-sops, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops, resolve-release-tag]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -2943,7 +2943,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git, converge-master-and-release-branches]
+    needs: [build-7-2-0-preview-9-alpine-3-11-20210819, build-7-2-0-preview-9-alpine-3-11-20210819-git-sops, build-7-1-4-alpine-3-11-20210819, build-7-1-4-alpine-3-11-20210819-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-preview-9-ubuntu-18-04-20210819, build-7-2-0-preview-9-ubuntu-18-04-20210819-git-sops, build-7-1-4-ubuntu-18-04-20210819, build-7-1-4-ubuntu-18-04-20210819-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops, converge-master-and-release-branches]
     # For Generate-DockerImageVariants: For CalVer releases. Each push to 'release' branch is a time-based release.
     # if: startsWith(github.ref, 'refs/tags/')
     if: github.ref == 'refs/heads/release'

--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
 | `:7.2.0-preview.9-alpine-3.11-20210819` | [View](variants/7.2.0-preview.9-alpine-3.11-20210819 ) |
-| `:7.2.0-preview.9-alpine-3.11-20210819-git` | [View](variants/7.2.0-preview.9-alpine-3.11-20210819-git ) |
+| `:7.2.0-preview.9-alpine-3.11-20210819-git-sops` | [View](variants/7.2.0-preview.9-alpine-3.11-20210819-git-sops ) |
 | `:7.1.4-alpine-3.11-20210819` | [View](variants/7.1.4-alpine-3.11-20210819 ) |
-| `:7.1.4-alpine-3.11-20210819-git` | [View](variants/7.1.4-alpine-3.11-20210819-git ) |
+| `:7.1.4-alpine-3.11-20210819-git-sops` | [View](variants/7.1.4-alpine-3.11-20210819-git-sops ) |
 | `:7.0.3-alpine-3.9-20200928` | [View](variants/7.0.3-alpine-3.9-20200928 ) |
-| `:7.0.3-alpine-3.9-20200928-git` | [View](variants/7.0.3-alpine-3.9-20200928-git ) |
+| `:7.0.3-alpine-3.9-20200928-git-sops` | [View](variants/7.0.3-alpine-3.9-20200928-git-sops ) |
 | `:6.2.4-alpine-3.8` | [View](variants/6.2.4-alpine-3.8 ) |
-| `:6.2.4-alpine-3.8-git` | [View](variants/6.2.4-alpine-3.8-git ) |
+| `:6.2.4-alpine-3.8-git-sops` | [View](variants/6.2.4-alpine-3.8-git-sops ) |
 | `:6.1.3-alpine-3.8` | [View](variants/6.1.3-alpine-3.8 ) |
-| `:6.1.3-alpine-3.8-git` | [View](variants/6.1.3-alpine-3.8-git ) |
+| `:6.1.3-alpine-3.8-git-sops` | [View](variants/6.1.3-alpine-3.8-git-sops ) |
 | `:7.2.0-preview.9-ubuntu-18.04-20210819` | [View](variants/7.2.0-preview.9-ubuntu-18.04-20210819 ) |
-| `:7.2.0-preview.9-ubuntu-18.04-20210819-git` | [View](variants/7.2.0-preview.9-ubuntu-18.04-20210819-git ) |
+| `:7.2.0-preview.9-ubuntu-18.04-20210819-git-sops` | [View](variants/7.2.0-preview.9-ubuntu-18.04-20210819-git-sops ) |
 | `:7.1.4-ubuntu-18.04-20210819` | [View](variants/7.1.4-ubuntu-18.04-20210819 ) |
-| `:7.1.4-ubuntu-18.04-20210819-git`, `:latest` | [View](variants/7.1.4-ubuntu-18.04-20210819-git ) |
+| `:7.1.4-ubuntu-18.04-20210819-git-sops`, `:latest` | [View](variants/7.1.4-ubuntu-18.04-20210819-git-sops ) |
 | `:7.0.3-ubuntu-18.04-20201027` | [View](variants/7.0.3-ubuntu-18.04-20201027 ) |
-| `:7.0.3-ubuntu-18.04-20201027-git` | [View](variants/7.0.3-ubuntu-18.04-20201027-git ) |
+| `:7.0.3-ubuntu-18.04-20201027-git-sops` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops ) |
 | `:6.2.4-ubuntu-18.04` | [View](variants/6.2.4-ubuntu-18.04 ) |
-| `:6.2.4-ubuntu-18.04-git` | [View](variants/6.2.4-ubuntu-18.04-git ) |
+| `:6.2.4-ubuntu-18.04-git-sops` | [View](variants/6.2.4-ubuntu-18.04-git-sops ) |
 | `:6.1.3-ubuntu-18.04` | [View](variants/6.1.3-ubuntu-18.04 ) |
-| `:6.1.3-ubuntu-18.04-git` | [View](variants/6.1.3-ubuntu-18.04-git ) |
+| `:6.1.3-ubuntu-18.04-git-sops` | [View](variants/6.1.3-ubuntu-18.04-git-sops ) |
 | `:6.0.2-ubuntu-16.04` | [View](variants/6.0.2-ubuntu-16.04 ) |
-| `:6.0.2-ubuntu-16.04-git` | [View](variants/6.0.2-ubuntu-16.04-git ) |
+| `:6.0.2-ubuntu-16.04-git-sops` | [View](variants/6.0.2-ubuntu-16.04-git-sops ) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -20,7 +20,7 @@ $local:VARIANTS_MATRIX = @(
             base_image_tag = $_
             subvariants = @(
                 @{ components = $null }
-                @{ components = @( 'git' ); tag_as_latest = if ($_ -eq $local:VARIANTS_BASE_IMAGE_TAG_LATEST_STABLE ) { $true } else { $false } }
+                @{ components = @( 'git', 'sops' ); tag_as_latest = if ($_ -eq $local:VARIANTS_BASE_IMAGE_TAG_LATEST_STABLE ) { $true } else { $false } }
             )
         }
     }

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -5,20 +5,64 @@ FROM mcr.microsoft.com/powershell:$( $VARIANT['_metadata']['base_image_tag'] )
 "@
 
 $VARIANT['_metadata']['components'] | ? { $_ } | % {
+    $component = $_
     if ( $VARIANT['_metadata']['base_image_tag'] -match '\balpine\b' ) {
-        @"
-RUN apk add --no-cache $_
+        switch ($component) {
+            'git' {
+                @"
+RUN apk add --no-cache git
 
 
 "@
+            }
+            'sops' {
+
+            @"
+# Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+
+
+"@
+            }
+            default {
+                throw "No such component: $component"
+            }
+        }
+
     }elseif ( $VARIANT['_metadata']['base_image_tag'] -match '\bubuntu\b' ) {
+        switch ($component) {
+            'git' {
         @"
 RUN apt-get update \
-    && apt-get install -y $_ \
+    && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
 
 
 "@
+            }
+            'sops' {
+
+            @"
+# Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+
+
+"@
+            }
+            default {
+                throw "No such component: $component"
+            }
+        }
     }else {
         throw "Only alpine and ubuntu base image tags supported"
     }

--- a/variants/6.0.2-ubuntu-16.04-git-sops/Dockerfile
+++ b/variants/6.0.2-ubuntu-16.04-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:6.0.2-ubuntu-16.04
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/6.1.3-alpine-3.8-git-sops/Dockerfile
+++ b/variants/6.1.3-alpine-3.8-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:6.1.3-alpine-3.8
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/6.1.3-ubuntu-18.04-git-sops/Dockerfile
+++ b/variants/6.1.3-ubuntu-18.04-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/6.2.4-alpine-3.8-git-sops/Dockerfile
+++ b/variants/6.2.4-alpine-3.8-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:6.2.4-alpine-3.8
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/6.2.4-ubuntu-18.04-git-sops/Dockerfile
+++ b/variants/6.2.4-ubuntu-18.04-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.0.3-alpine-3.9-20200928-git-sops/Dockerfile
+++ b/variants/7.0.3-alpine-3.9-20200928-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.9-20200928
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/7.0.3-ubuntu-18.04-20201027-git-sops/Dockerfile
+++ b/variants/7.0.3-ubuntu-18.04-20201027-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04-20201027
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.1.4-alpine-3.11-20210819-git-sops/Dockerfile
+++ b/variants/7.1.4-alpine-3.11-20210819-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:7.1.4-alpine-3.11-20210819
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/7.1.4-ubuntu-18.04-20210819-git-sops/Dockerfile
+++ b/variants/7.1.4-ubuntu-18.04-20210819-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:7.1.4-ubuntu-18.04-20210819
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.2.0-preview.9-alpine-3.11-20210819-git-sops/Dockerfile
+++ b/variants/7.2.0-preview.9-alpine-3.11-20210819-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:7.2.0-preview.9-alpine-3.11-20210819
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/7.2.0-preview.9-ubuntu-18.04-20210819-git-sops/Dockerfile
+++ b/variants/7.2.0-preview.9-ubuntu-18.04-20210819-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:7.2.0-preview.9-ubuntu-18.04-20210819
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
Note that for ubuntu-16.04 variants, the package is `gpgv2` which installs:

```
root@c597dfd5ed49:/# gpgv2 --version
gpgv (GnuPG) 2.1.11
libgcrypt 1.6.5
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

Hence, it might not be compatible with `sops` v2. See: https://github.com/mozilla/sops/issues/189