### PR TITLE
Enhancement: Build multi arch docker image

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -94,7 +94,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -109,7 +109,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -124,7 +124,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -224,7 +224,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -239,7 +239,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -254,7 +254,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -354,7 +354,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -369,7 +369,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -384,7 +384,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -484,7 +484,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -499,7 +499,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -514,7 +514,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -614,7 +614,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -629,7 +629,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -644,7 +644,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -744,7 +744,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -759,7 +759,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -774,7 +774,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -874,7 +874,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -889,7 +889,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -904,7 +904,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1004,7 +1004,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1019,7 +1019,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1034,7 +1034,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1134,7 +1134,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1149,7 +1149,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1164,7 +1164,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1264,7 +1264,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1279,7 +1279,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1294,7 +1294,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1394,7 +1394,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1409,7 +1409,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1424,7 +1424,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1524,7 +1524,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1539,7 +1539,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1554,7 +1554,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1654,7 +1654,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1669,7 +1669,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1684,7 +1684,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1784,7 +1784,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1799,7 +1799,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1814,7 +1814,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -1915,7 +1915,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1930,7 +1930,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -1945,7 +1945,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2045,7 +2045,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2060,7 +2060,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2075,7 +2075,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2175,7 +2175,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2190,7 +2190,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2205,7 +2205,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2305,7 +2305,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2320,7 +2320,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2335,7 +2335,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2435,7 +2435,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2450,7 +2450,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2465,7 +2465,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2565,7 +2565,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2580,7 +2580,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2595,7 +2595,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2695,7 +2695,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2710,7 +2710,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2725,7 +2725,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
@@ -2825,7 +2825,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2840,7 +2840,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -2855,7 +2855,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -13,7 +13,7 @@ jobs:
 '@
 
 $local:WORKFLOW_JOB_NAMES = $VARIANTS | % { "build-$( $_['tag'].Replace('.', '-') )" }
-$( $VARIANTS | % {
+$VARIANTS | % {
 @"
 
 
@@ -97,18 +97,21 @@ $( $VARIANTS | % {
         DOCKERHUB_REGISTRY_USER: ${{ secrets.DOCKERHUB_REGISTRY_USER }}
         DOCKERHUB_REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
 
+
+'@
+@"
     - name: Build (PRs)
       id: docker_build_pr
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -118,12 +121,12 @@ $( $VARIANTS | % {
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
@@ -133,15 +136,15 @@ $( $VARIANTS | % {
       if: github.ref == 'refs/heads/release'
       uses: docker/build-push-action@v2
       with:
-        context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        context: `${{ steps.prep.outputs.CONTEXT }}
+        platforms: $( if ($_['_metadata']['distro'] -eq 'alpine' -and $_['_metadata']['distro_version'] -in @( '3.3', '3.4', '3.5' ) ) { 'linux/amd64' } else { 'linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x' } )
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
-          ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
+          `${{ github.repository }}:`${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
 
-'@
+"@
 
 if ( $_['tag_as_latest'] ) {
 @'
@@ -160,7 +163,7 @@ if ( $_['tag_as_latest'] ) {
       run: docker logout
       if: always()
 '@
-})
+}
 
 @"
 


### PR DESCRIPTION
Note: There's only `linux/amd64` image for`alpine:3.3` to `alpine:3.5`, see https://hub.docker.com/_/alpine?tab=tags&page=1&ordering=last_updated&name=3.5