### PR TITLE
Enhancement: Bump powershell 7.1 variants distros to alpine 3.13 and ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -265,11 +265,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-5-alpine-3-11-20211021:
+  build-7-1-5-alpine-3-13-20211021:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.5-alpine-3.11-20211021
-      VARIANT_BUILD_DIR: variants/7.1.5-alpine-3.11-20211021
+      VARIANT_TAG: 7.1.5-alpine-3.13-20211021
+      VARIANT_BUILD_DIR: variants/7.1.5-alpine-3.13-20211021
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -392,11 +392,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-5-alpine-3-11-20211021-git-sops:
+  build-7-1-5-alpine-3-13-20211021-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.5-alpine-3.11-20211021-git-sops
-      VARIANT_BUILD_DIR: variants/7.1.5-alpine-3.11-20211021-git-sops
+      VARIANT_TAG: 7.1.5-alpine-3.13-20211021-git-sops
+      VARIANT_BUILD_DIR: variants/7.1.5-alpine-3.13-20211021-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1535,11 +1535,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-5-ubuntu-18-04-20211021:
+  build-7-1-5-ubuntu-20-04-20211021:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.5-ubuntu-18.04-20211021
-      VARIANT_BUILD_DIR: variants/7.1.5-ubuntu-18.04-20211021
+      VARIANT_TAG: 7.1.5-ubuntu-20.04-20211021
+      VARIANT_BUILD_DIR: variants/7.1.5-ubuntu-20.04-20211021
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1662,11 +1662,11 @@ jobs:
       run: docker logout
       if: always()
 
-  build-7-1-5-ubuntu-18-04-20211021-git-sops:
+  build-7-1-5-ubuntu-20-04-20211021-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT_TAG: 7.1.5-ubuntu-18.04-20211021-git-sops
-      VARIANT_BUILD_DIR: variants/7.1.5-ubuntu-18.04-20211021-git-sops
+      VARIANT_TAG: 7.1.5-ubuntu-20.04-20211021-git-sops
+      VARIANT_BUILD_DIR: variants/7.1.5-ubuntu-20.04-20211021-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -1779,7 +1779,6 @@ jobs:
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-          ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2034,6 +2033,7 @@ jobs:
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2807,7 +2807,7 @@ jobs:
       if: always()
 
   update-draft-release:
-    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-11-20211021, build-7-1-5-alpine-3-11-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-18-04-20211021, build-7-1-5-ubuntu-18-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
+    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-13-20211021, build-7-1-5-alpine-3-13-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-20-04-20211021, build-7-1-5-ubuntu-20-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -2821,7 +2821,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-11-20211021, build-7-1-5-alpine-3-11-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-18-04-20211021, build-7-1-5-ubuntu-18-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
+    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-13-20211021, build-7-1-5-alpine-3-13-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-20-04-20211021, build-7-1-5-ubuntu-20-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 |:-------:|:---------:|
 | `:7.2.0-alpine-3.14-20211102` | [View](variants/7.2.0-alpine-3.14-20211102 ) |
 | `:7.2.0-alpine-3.14-20211102-git-sops` | [View](variants/7.2.0-alpine-3.14-20211102-git-sops ) |
-| `:7.1.5-alpine-3.11-20211021` | [View](variants/7.1.5-alpine-3.11-20211021 ) |
-| `:7.1.5-alpine-3.11-20211021-git-sops` | [View](variants/7.1.5-alpine-3.11-20211021-git-sops ) |
+| `:7.1.5-alpine-3.13-20211021` | [View](variants/7.1.5-alpine-3.13-20211021 ) |
+| `:7.1.5-alpine-3.13-20211021-git-sops` | [View](variants/7.1.5-alpine-3.13-20211021-git-sops ) |
 | `:7.0.3-alpine-3.9-20200928` | [View](variants/7.0.3-alpine-3.9-20200928 ) |
 | `:7.0.3-alpine-3.9-20200928-git-sops` | [View](variants/7.0.3-alpine-3.9-20200928-git-sops ) |
 | `:6.2.4-alpine-3.8` | [View](variants/6.2.4-alpine-3.8 ) |
@@ -22,10 +22,10 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 | `:6.1.3-alpine-3.8-git-sops` | [View](variants/6.1.3-alpine-3.8-git-sops ) |
 | `:7.2.0-ubuntu-20.04-20211102` | [View](variants/7.2.0-ubuntu-20.04-20211102 ) |
 | `:7.2.0-ubuntu-20.04-20211102-git-sops` | [View](variants/7.2.0-ubuntu-20.04-20211102-git-sops ) |
-| `:7.1.5-ubuntu-18.04-20211021` | [View](variants/7.1.5-ubuntu-18.04-20211021 ) |
-| `:7.1.5-ubuntu-18.04-20211021-git-sops`, `:latest` | [View](variants/7.1.5-ubuntu-18.04-20211021-git-sops ) |
+| `:7.1.5-ubuntu-20.04-20211021` | [View](variants/7.1.5-ubuntu-20.04-20211021 ) |
+| `:7.1.5-ubuntu-20.04-20211021-git-sops` | [View](variants/7.1.5-ubuntu-20.04-20211021-git-sops ) |
 | `:7.0.3-ubuntu-18.04-20201027` | [View](variants/7.0.3-ubuntu-18.04-20201027 ) |
-| `:7.0.3-ubuntu-18.04-20201027-git-sops` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops ) |
+| `:7.0.3-ubuntu-18.04-20201027-git-sops`, `:latest` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops ) |
 | `:6.2.4-ubuntu-18.04` | [View](variants/6.2.4-ubuntu-18.04 ) |
 | `:6.2.4-ubuntu-18.04-git-sops` | [View](variants/6.2.4-ubuntu-18.04-git-sops ) |
 | `:6.1.3-ubuntu-18.04` | [View](variants/6.1.3-ubuntu-18.04 ) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,13 +1,13 @@
 # Docker image variants' definitions
 $local:VARIANTS_BASE_IMAGE_TAGS = @(
     '7.2.0-alpine-3.14-20211102'
-    '7.1.5-alpine-3.11-20211021'
+    '7.1.5-alpine-3.13-20211021'
     '7.0.3-alpine-3.9-20200928'
     '6.2.4-alpine-3.8'
     '6.1.3-alpine-3.8'
 
     '7.2.0-ubuntu-20.04-20211102'
-    '7.1.5-ubuntu-18.04-20211021'
+    '7.1.5-ubuntu-20.04-20211021'
     '7.0.3-ubuntu-18.04-20201027'
     '6.2.4-ubuntu-18.04'
     '6.1.3-ubuntu-18.04'

--- a/variants/7.1.5-alpine-3.13-20211021-git-sops/Dockerfile
+++ b/variants/7.1.5-alpine-3.13-20211021-git-sops/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13-20211021
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
+

--- a/variants/7.1.5-alpine-3.13-20211021/Dockerfile
+++ b/variants/7.1.5-alpine-3.13-20211021/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13-20211021
+

--- a/variants/7.1.5-ubuntu-20.04-20211021-git-sops/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04-20211021-git-sops/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04-20211021
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.1.5-ubuntu-20.04-20211021/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04-20211021/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04-20211021
+


### PR DESCRIPTION
The latest versions of powershell ought to be running on newer distros for better support, and less differences among images.