### PR TITLE
Fix (ci): Tag powershell 7.2 ubuntu 20.04 non-bare variant as latest

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -1525,6 +1525,7 @@ jobs:
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+          ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -2033,7 +2034,6 @@ jobs:
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
-          ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 | `:6.1.3-alpine-3.8` | [View](variants/6.1.3-alpine-3.8 ) |
 | `:6.1.3-alpine-3.8-git-sops` | [View](variants/6.1.3-alpine-3.8-git-sops ) |
 | `:7.2.0-ubuntu-20.04-20211102` | [View](variants/7.2.0-ubuntu-20.04-20211102 ) |
-| `:7.2.0-ubuntu-20.04-20211102-git-sops` | [View](variants/7.2.0-ubuntu-20.04-20211102-git-sops ) |
+| `:7.2.0-ubuntu-20.04-20211102-git-sops`, `:latest` | [View](variants/7.2.0-ubuntu-20.04-20211102-git-sops ) |
 | `:7.1.5-ubuntu-20.04-20211021` | [View](variants/7.1.5-ubuntu-20.04-20211021 ) |
 | `:7.1.5-ubuntu-20.04-20211021-git-sops` | [View](variants/7.1.5-ubuntu-20.04-20211021-git-sops ) |
 | `:7.0.3-ubuntu-18.04-20201027` | [View](variants/7.0.3-ubuntu-18.04-20201027 ) |
-| `:7.0.3-ubuntu-18.04-20201027-git-sops`, `:latest` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops ) |
+| `:7.0.3-ubuntu-18.04-20201027-git-sops` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops ) |
 | `:6.2.4-ubuntu-18.04` | [View](variants/6.2.4-ubuntu-18.04 ) |
 | `:6.2.4-ubuntu-18.04-git-sops` | [View](variants/6.2.4-ubuntu-18.04-git-sops ) |
 | `:6.1.3-ubuntu-18.04` | [View](variants/6.1.3-ubuntu-18.04 ) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -13,7 +13,7 @@ $local:VARIANTS_BASE_IMAGE_TAGS = @(
     '6.1.3-ubuntu-18.04'
     '6.0.2-ubuntu-16.04'
 )
-$local:VARIANTS_BASE_IMAGE_TAG_LATEST_STABLE = $VARIANTS_BASE_IMAGE_TAGS | Sort-Object -Descending -Property @{ Expression={ if ($_ -match '^(v?\d+\.\d+\.\d+)') { [version]$matches[1] } } } | ? { $_ -notmatch 'preview' -and $_ -match 'ubuntu\-18.04' } | Select-Object -First 1
+$local:VARIANTS_BASE_IMAGE_TAG_LATEST_STABLE = $local:VARIANTS_BASE_IMAGE_TAGS | ? { $_ -match 'ubuntu' } | Select-Object -First 1
 $local:VARIANTS_MATRIX = @(
     $local:VARIANTS_BASE_IMAGE_TAGS | % {
         @{


### PR DESCRIPTION
Related: #15