### PR TITLE
Enhancement: Disable powershell startup telemetry, startup update check, and diagnostics in all variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -1,6 +1,15 @@
 @"
 FROM mcr.microsoft.com/powershell:$( $VARIANT['_metadata']['base_image_tag'] )
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 
 "@
 
@@ -17,7 +26,7 @@ RUN apk add --no-cache git
             }
             'sops' {
 
-            @"
+                @"
 # Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
 RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
@@ -34,7 +43,7 @@ RUN apk add --no-cache gnupg
     }elseif ( $VARIANT['_metadata']['base_image_tag'] -match '\bubuntu\b' ) {
         switch ($component) {
             'git' {
-        @"
+                @"
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -43,14 +52,12 @@ RUN apt-get update \
 "@
             }
             'sops' {
-
-            @"
+                @"
 # Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
 RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/6.0.2-ubuntu-16.04-git-sops/Dockerfile
+++ b/variants/6.0.2-ubuntu-16.04-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:6.0.2-ubuntu-16.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/6.0.2-ubuntu-16.04/Dockerfile
+++ b/variants/6.0.2-ubuntu-16.04/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:6.0.2-ubuntu-16.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/6.1.3-alpine-3.8-git-sops/Dockerfile
+++ b/variants/6.1.3-alpine-3.8-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:6.1.3-alpine-3.8
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apk add --no-cache git
 
 # Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.

--- a/variants/6.1.3-alpine-3.8/Dockerfile
+++ b/variants/6.1.3-alpine-3.8/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:6.1.3-alpine-3.8
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/6.1.3-ubuntu-18.04-git-sops/Dockerfile
+++ b/variants/6.1.3-ubuntu-18.04-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/6.1.3-ubuntu-18.04/Dockerfile
+++ b/variants/6.1.3-ubuntu-18.04/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/6.2.4-alpine-3.8-git-sops/Dockerfile
+++ b/variants/6.2.4-alpine-3.8-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:6.2.4-alpine-3.8
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apk add --no-cache git
 
 # Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.

--- a/variants/6.2.4-alpine-3.8/Dockerfile
+++ b/variants/6.2.4-alpine-3.8/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:6.2.4-alpine-3.8
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/6.2.4-ubuntu-18.04-git-sops/Dockerfile
+++ b/variants/6.2.4-ubuntu-18.04-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/6.2.4-ubuntu-18.04/Dockerfile
+++ b/variants/6.2.4-ubuntu-18.04/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.0.3-alpine-3.9-20200928-git-sops/Dockerfile
+++ b/variants/7.0.3-alpine-3.9-20200928-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.9-20200928
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apk add --no-cache git
 
 # Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.

--- a/variants/7.0.3-alpine-3.9-20200928/Dockerfile
+++ b/variants/7.0.3-alpine-3.9-20200928/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.9-20200928
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.0.3-ubuntu-18.04-20201027-git-sops/Dockerfile
+++ b/variants/7.0.3-ubuntu-18.04-20201027-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04-20201027
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/7.0.3-ubuntu-18.04-20201027/Dockerfile
+++ b/variants/7.0.3-ubuntu-18.04-20201027/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04-20201027
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.1.5-alpine-3.13-20211021-git-sops/Dockerfile
+++ b/variants/7.1.5-alpine-3.13-20211021-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13-20211021
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apk add --no-cache git
 
 # Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.

--- a/variants/7.1.5-alpine-3.13-20211021/Dockerfile
+++ b/variants/7.1.5-alpine-3.13-20211021/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13-20211021
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.1.5-ubuntu-20.04-20211021-git-sops/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04-20211021-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04-20211021
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/7.1.5-ubuntu-20.04-20211021/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04-20211021/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04-20211021
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.2.0-alpine-3.14-20211102-git-sops/Dockerfile
+++ b/variants/7.2.0-alpine-3.14-20211102-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.2.0-alpine-3.14-20211102
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apk add --no-cache git
 
 # Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.

--- a/variants/7.2.0-alpine-3.14-20211102/Dockerfile
+++ b/variants/7.2.0-alpine-3.14-20211102/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.2.0-alpine-3.14-20211102
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+

--- a/variants/7.2.0-ubuntu-20.04-20211102-git-sops/Dockerfile
+++ b/variants/7.2.0-ubuntu-20.04-20211102-git-sops/Dockerfile
@@ -1,5 +1,14 @@
 FROM mcr.microsoft.com/powershell:7.2.0-ubuntu-20.04-20211102
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -9,7 +18,6 @@ RUN apt-get update \
     && apt-get install -y wget \
     && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN apt-get update \
     && (apt-get install -y gpg || apt-get install -y gpgv2) \

--- a/variants/7.2.0-ubuntu-20.04-20211102/Dockerfile
+++ b/variants/7.2.0-ubuntu-20.04-20211102/Dockerfile
@@ -1,2 +1,11 @@
 FROM mcr.microsoft.com/powershell:7.2.0-ubuntu-20.04-20211102
 
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+


### PR DESCRIPTION
Since powershell 7.0, on shell initialization, telemetry is sent by default. Update check slows down shell initialization. Diagnostics is generally unneeded.

Now these are disabled.