### PR TITLE
Refactor: Use base image tags without calver

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -32,10 +32,10 @@ jobs:
       run: |
         git diff --exit-code
 
-  build-7-2-0-alpine-3-14-20211102:
+  build-7-2-0-alpine-3-14:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.0-alpine-3.14-20211102
+      VARIANT: 7.2.0-alpine-3.14
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -107,7 +107,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102
+        context: variants/7.2.0-alpine-3.14
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -121,7 +121,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102
+        context: variants/7.2.0-alpine-3.14
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -134,7 +134,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102
+        context: variants/7.2.0-alpine-3.14
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -152,10 +152,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-0-alpine-3-14-20211102-git-sops:
+  build-7-2-0-alpine-3-14-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.0-alpine-3.14-20211102-git-sops
+      VARIANT: 7.2.0-alpine-3.14-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -227,7 +227,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102-git-sops
+        context: variants/7.2.0-alpine-3.14-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -241,7 +241,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102-git-sops
+        context: variants/7.2.0-alpine-3.14-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -254,7 +254,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-alpine-3.14-20211102-git-sops
+        context: variants/7.2.0-alpine-3.14-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -272,10 +272,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-1-5-alpine-3-13-20211021:
+  build-7-1-5-alpine-3-13:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.1.5-alpine-3.13-20211021
+      VARIANT: 7.1.5-alpine-3.13
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -347,7 +347,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021
+        context: variants/7.1.5-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -361,7 +361,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021
+        context: variants/7.1.5-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -374,7 +374,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021
+        context: variants/7.1.5-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -392,10 +392,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-1-5-alpine-3-13-20211021-git-sops:
+  build-7-1-5-alpine-3-13-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.1.5-alpine-3.13-20211021-git-sops
+      VARIANT: 7.1.5-alpine-3.13-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -467,7 +467,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021-git-sops
+        context: variants/7.1.5-alpine-3.13-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -481,7 +481,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021-git-sops
+        context: variants/7.1.5-alpine-3.13-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -494,7 +494,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-alpine-3.13-20211021-git-sops
+        context: variants/7.1.5-alpine-3.13-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -512,10 +512,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-0-3-alpine-3-9-20200928:
+  build-7-0-3-alpine-3-9:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.0.3-alpine-3.9-20200928
+      VARIANT: 7.0.3-alpine-3.9
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -587,7 +587,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928
+        context: variants/7.0.3-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -601,7 +601,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928
+        context: variants/7.0.3-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -614,7 +614,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928
+        context: variants/7.0.3-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -632,10 +632,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-0-3-alpine-3-9-20200928-git-sops:
+  build-7-0-3-alpine-3-9-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.0.3-alpine-3.9-20200928-git-sops
+      VARIANT: 7.0.3-alpine-3.9-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -707,7 +707,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928-git-sops
+        context: variants/7.0.3-alpine-3.9-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -721,7 +721,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928-git-sops
+        context: variants/7.0.3-alpine-3.9-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -734,7 +734,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-alpine-3.9-20200928-git-sops
+        context: variants/7.0.3-alpine-3.9-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1232,10 +1232,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-0-ubuntu-20-04-20211102:
+  build-7-2-0-ubuntu-20-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.0-ubuntu-20.04-20211102
+      VARIANT: 7.2.0-ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1307,7 +1307,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102
+        context: variants/7.2.0-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1321,7 +1321,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102
+        context: variants/7.2.0-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1334,7 +1334,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102
+        context: variants/7.2.0-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1352,10 +1352,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-0-ubuntu-20-04-20211102-git-sops:
+  build-7-2-0-ubuntu-20-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.0-ubuntu-20.04-20211102-git-sops
+      VARIANT: 7.2.0-ubuntu-20.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1427,7 +1427,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102-git-sops
+        context: variants/7.2.0-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1441,7 +1441,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102-git-sops
+        context: variants/7.2.0-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1454,7 +1454,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.0-ubuntu-20.04-20211102-git-sops
+        context: variants/7.2.0-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1473,10 +1473,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-1-5-ubuntu-20-04-20211021:
+  build-7-1-5-ubuntu-20-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.1.5-ubuntu-20.04-20211021
+      VARIANT: 7.1.5-ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1548,7 +1548,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021
+        context: variants/7.1.5-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1562,7 +1562,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021
+        context: variants/7.1.5-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1575,7 +1575,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021
+        context: variants/7.1.5-ubuntu-20.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1593,10 +1593,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-1-5-ubuntu-20-04-20211021-git-sops:
+  build-7-1-5-ubuntu-20-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.1.5-ubuntu-20.04-20211021-git-sops
+      VARIANT: 7.1.5-ubuntu-20.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1668,7 +1668,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021-git-sops
+        context: variants/7.1.5-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1682,7 +1682,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021-git-sops
+        context: variants/7.1.5-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1695,7 +1695,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.1.5-ubuntu-20.04-20211021-git-sops
+        context: variants/7.1.5-ubuntu-20.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1713,10 +1713,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-0-3-ubuntu-18-04-20201027:
+  build-7-0-3-ubuntu-18-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.0.3-ubuntu-18.04-20201027
+      VARIANT: 7.0.3-ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1788,7 +1788,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027
+        context: variants/7.0.3-ubuntu-18.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1802,7 +1802,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027
+        context: variants/7.0.3-ubuntu-18.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1815,7 +1815,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027
+        context: variants/7.0.3-ubuntu-18.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1833,10 +1833,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-0-3-ubuntu-18-04-20201027-git-sops:
+  build-7-0-3-ubuntu-18-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.0.3-ubuntu-18.04-20201027-git-sops
+      VARIANT: 7.0.3-ubuntu-18.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1908,7 +1908,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027-git-sops
+        context: variants/7.0.3-ubuntu-18.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1922,7 +1922,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027-git-sops
+        context: variants/7.0.3-ubuntu-18.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1935,7 +1935,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.0.3-ubuntu-18.04-20201027-git-sops
+        context: variants/7.0.3-ubuntu-18.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -2674,7 +2674,7 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   update-draft-release:
-    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-13-20211021, build-7-1-5-alpine-3-13-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-20-04-20211021, build-7-1-5-ubuntu-20-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
+    needs: [build-7-2-0-alpine-3-14, build-7-2-0-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04, build-7-2-0-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -2687,7 +2687,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-13-20211021, build-7-1-5-alpine-3-13-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-20-04-20211021, build-7-1-5-ubuntu-20-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
+    needs: [build-7-2-0-alpine-3-14, build-7-2-0-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04, build-7-2-0-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -2702,7 +2702,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-dockerhub-description:
-    needs: [build-7-2-0-alpine-3-14-20211102, build-7-2-0-alpine-3-14-20211102-git-sops, build-7-1-5-alpine-3-13-20211021, build-7-1-5-alpine-3-13-20211021-git-sops, build-7-0-3-alpine-3-9-20200928, build-7-0-3-alpine-3-9-20200928-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04-20211102, build-7-2-0-ubuntu-20-04-20211102-git-sops, build-7-1-5-ubuntu-20-04-20211021, build-7-1-5-ubuntu-20-04-20211021-git-sops, build-7-0-3-ubuntu-18-04-20201027, build-7-0-3-ubuntu-18-04-20201027-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
+    needs: [build-7-2-0-alpine-3-14, build-7-2-0-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-2-0-ubuntu-20-04, build-7-2-0-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-2-ubuntu-16-04, build-6-0-2-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:7.2.0-alpine-3.14-20211102` | [View](variants/7.2.0-alpine-3.14-20211102) |
-| `:7.2.0-alpine-3.14-20211102-git-sops` | [View](variants/7.2.0-alpine-3.14-20211102-git-sops) |
-| `:7.1.5-alpine-3.13-20211021` | [View](variants/7.1.5-alpine-3.13-20211021) |
-| `:7.1.5-alpine-3.13-20211021-git-sops` | [View](variants/7.1.5-alpine-3.13-20211021-git-sops) |
-| `:7.0.3-alpine-3.9-20200928` | [View](variants/7.0.3-alpine-3.9-20200928) |
-| `:7.0.3-alpine-3.9-20200928-git-sops` | [View](variants/7.0.3-alpine-3.9-20200928-git-sops) |
+| `:7.2.0-alpine-3.14` | [View](variants/7.2.0-alpine-3.14) |
+| `:7.2.0-alpine-3.14-git-sops` | [View](variants/7.2.0-alpine-3.14-git-sops) |
+| `:7.1.5-alpine-3.13` | [View](variants/7.1.5-alpine-3.13) |
+| `:7.1.5-alpine-3.13-git-sops` | [View](variants/7.1.5-alpine-3.13-git-sops) |
+| `:7.0.3-alpine-3.9` | [View](variants/7.0.3-alpine-3.9) |
+| `:7.0.3-alpine-3.9-git-sops` | [View](variants/7.0.3-alpine-3.9-git-sops) |
 | `:6.2.4-alpine-3.8` | [View](variants/6.2.4-alpine-3.8) |
 | `:6.2.4-alpine-3.8-git-sops` | [View](variants/6.2.4-alpine-3.8-git-sops) |
 | `:6.1.3-alpine-3.8` | [View](variants/6.1.3-alpine-3.8) |
 | `:6.1.3-alpine-3.8-git-sops` | [View](variants/6.1.3-alpine-3.8-git-sops) |
-| `:7.2.0-ubuntu-20.04-20211102` | [View](variants/7.2.0-ubuntu-20.04-20211102) |
-| `:7.2.0-ubuntu-20.04-20211102-git-sops`, `:latest` | [View](variants/7.2.0-ubuntu-20.04-20211102-git-sops) |
-| `:7.1.5-ubuntu-20.04-20211021` | [View](variants/7.1.5-ubuntu-20.04-20211021) |
-| `:7.1.5-ubuntu-20.04-20211021-git-sops` | [View](variants/7.1.5-ubuntu-20.04-20211021-git-sops) |
-| `:7.0.3-ubuntu-18.04-20201027` | [View](variants/7.0.3-ubuntu-18.04-20201027) |
-| `:7.0.3-ubuntu-18.04-20201027-git-sops` | [View](variants/7.0.3-ubuntu-18.04-20201027-git-sops) |
+| `:7.2.0-ubuntu-20.04` | [View](variants/7.2.0-ubuntu-20.04) |
+| `:7.2.0-ubuntu-20.04-git-sops`, `:latest` | [View](variants/7.2.0-ubuntu-20.04-git-sops) |
+| `:7.1.5-ubuntu-20.04` | [View](variants/7.1.5-ubuntu-20.04) |
+| `:7.1.5-ubuntu-20.04-git-sops` | [View](variants/7.1.5-ubuntu-20.04-git-sops) |
+| `:7.0.3-ubuntu-18.04` | [View](variants/7.0.3-ubuntu-18.04) |
+| `:7.0.3-ubuntu-18.04-git-sops` | [View](variants/7.0.3-ubuntu-18.04-git-sops) |
 | `:6.2.4-ubuntu-18.04` | [View](variants/6.2.4-ubuntu-18.04) |
 | `:6.2.4-ubuntu-18.04-git-sops` | [View](variants/6.2.4-ubuntu-18.04-git-sops) |
 | `:6.1.3-ubuntu-18.04` | [View](variants/6.1.3-ubuntu-18.04) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,14 +1,14 @@
 # Docker image variants' definitions
 $local:VARIANTS_BASE_IMAGE_TAGS = @(
-    '7.2.0-alpine-3.14-20211102'
-    '7.1.5-alpine-3.13-20211021'
-    '7.0.3-alpine-3.9-20200928'
+    '7.2.0-alpine-3.14'
+    '7.1.5-alpine-3.13'
+    '7.0.3-alpine-3.9'
     '6.2.4-alpine-3.8'
     '6.1.3-alpine-3.8'
 
-    '7.2.0-ubuntu-20.04-20211102'
-    '7.1.5-ubuntu-20.04-20211021'
-    '7.0.3-ubuntu-18.04-20201027'
+    '7.2.0-ubuntu-20.04'
+    '7.1.5-ubuntu-20.04'
+    '7.0.3-ubuntu-18.04'
     '6.2.4-ubuntu-18.04'
     '6.1.3-ubuntu-18.04'
     '6.0.2-ubuntu-16.04'

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -16,12 +16,11 @@ RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 
 
 "@
 
-$VARIANT['_metadata']['components'] | ? { $_ } | % {
-    $component = $_
+foreach ($c in $VARIANT['_metadata']['components']) {
     if ( $VARIANT['_metadata']['base_image_tag'] -match '\balpine\b' ) {
-        switch ($component) {
+        switch ($c) {
             'git' {
-                @"
+@"
 RUN apk add --no-cache git
 
 
@@ -29,7 +28,7 @@ RUN apk add --no-cache git
             }
             'sops' {
 
-                @"
+@"
 # Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
 RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
 
@@ -44,9 +43,9 @@ RUN apk add --no-cache gnupg
         }
 
     }elseif ( $VARIANT['_metadata']['base_image_tag'] -match '\bubuntu\b' ) {
-        switch ($component) {
+        switch ($c) {
             'git' {
-                @"
+@"
 RUN apt-get update \
     && apt-get install -y git \
     && rm -rf /var/lib/apt/lists/*
@@ -55,7 +54,7 @@ RUN apt-get update \
 "@
             }
             'sops' {
-                @"
+@"
 # Note: `sops` does not provide binaries for other arch other than `linux/i386` and `linux/amd64`. So `sops` might not work on other architectures.
 RUN apt-get update \
     && apt-get install -y wget \

--- a/variants/7.0.3-alpine-3.9-git-sops/Dockerfile
+++ b/variants/7.0.3-alpine-3.9-git-sops/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.9
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
@@ -11,4 +11,11 @@ ENV COMPlus_EnableDiagnostics=0
 
 # Install Pester
 RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
 

--- a/variants/7.0.3-alpine-3.9/Dockerfile
+++ b/variants/7.0.3-alpine-3.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.9
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1

--- a/variants/7.0.3-ubuntu-18.04-git-sops/Dockerfile
+++ b/variants/7.0.3-ubuntu-18.04-git-sops/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.1.5-alpine-3.13-git-sops/Dockerfile
+++ b/variants/7.1.5-alpine-3.13-git-sops/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
@@ -11,4 +11,11 @@ ENV COMPlus_EnableDiagnostics=0
 
 # Install Pester
 RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
 

--- a/variants/7.1.5-alpine-3.13/Dockerfile
+++ b/variants/7.1.5-alpine-3.13/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.1.5-alpine-3.13
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1

--- a/variants/7.1.5-ubuntu-20.04-git-sops/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04-git-sops/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.1.5-ubuntu-20.04/Dockerfile
+++ b/variants/7.1.5-ubuntu-20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.1.5-ubuntu-20.04
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1

--- a/variants/7.2.0-alpine-3.14-git-sops/Dockerfile
+++ b/variants/7.2.0-alpine-3.14-git-sops/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.2.0-alpine-3.14
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
@@ -11,4 +11,11 @@ ENV COMPlus_EnableDiagnostics=0
 
 # Install Pester
 RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache git
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops
+
+RUN apk add --no-cache gnupg
 

--- a/variants/7.2.0-alpine-3.14/Dockerfile
+++ b/variants/7.2.0-alpine-3.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.2.0-alpine-3.14
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1

--- a/variants/7.2.0-ubuntu-20.04-git-sops/Dockerfile
+++ b/variants/7.2.0-ubuntu-20.04-git-sops/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/powershell:7.2.0-ubuntu-20.04
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Note: sops does not provide binaries for other arch other than linux/i386 and linux/amd64. So sops might not work on other architectures.
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops && chmod +x /usr/local/bin/sops \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && (apt-get install -y gpg || apt-get install -y gpgv2) \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/variants/7.2.0-ubuntu-20.04/Dockerfile
+++ b/variants/7.2.0-ubuntu-20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.2.0-ubuntu-20.04
 
 # Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
 ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
In general the base image tags are not very meaningful. For simplicity, simply use the base tags without calver.
