### PR TITLE
Enhancement: Bump v7.2 variants to v7.2.14 (tag is now 7.2-<distro>)

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -272,10 +272,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-2-alpine-3-14:
+  build-7-2-alpine-3-17:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.2-alpine-3.14
+      VARIANT: 7.2-alpine-3.17
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -347,7 +347,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14
+        context: variants/7.2-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -361,7 +361,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14
+        context: variants/7.2-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -374,7 +374,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14
+        context: variants/7.2-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -392,10 +392,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-2-alpine-3-14-git-sops:
+  build-7-2-alpine-3-17-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.2-alpine-3.14-git-sops
+      VARIANT: 7.2-alpine-3.17-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -467,7 +467,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14-git-sops
+        context: variants/7.2-alpine-3.17-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -481,7 +481,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14-git-sops
+        context: variants/7.2-alpine-3.17-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -494,7 +494,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-alpine-3.14-git-sops
+        context: variants/7.2-alpine-3.17-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1713,10 +1713,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-2-ubuntu-20-04:
+  build-7-2-ubuntu-22-04:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.2-ubuntu-20.04
+      VARIANT: 7.2-ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1788,7 +1788,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04
+        context: variants/7.2-ubuntu-22.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1802,7 +1802,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04
+        context: variants/7.2-ubuntu-22.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1815,7 +1815,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04
+        context: variants/7.2-ubuntu-22.04
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1833,10 +1833,10 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-7-2-2-ubuntu-20-04-git-sops:
+  build-7-2-ubuntu-22-04-git-sops:
     runs-on: ubuntu-latest
     env:
-      VARIANT: 7.2.2-ubuntu-20.04-git-sops
+      VARIANT: 7.2-ubuntu-22.04-git-sops
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -1908,7 +1908,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04-git-sops
+        context: variants/7.2-ubuntu-22.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
@@ -1922,7 +1922,7 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04-git-sops
+        context: variants/7.2-ubuntu-22.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -1935,7 +1935,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/7.2.2-ubuntu-20.04-git-sops
+        context: variants/7.2-ubuntu-22.04-git-sops
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
@@ -3154,7 +3154,7 @@ jobs:
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   update-draft-release:
-    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-2-alpine-3-14, build-7-2-2-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-2-ubuntu-20-04, build-7-2-2-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
+    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-alpine-3-17, build-7-2-alpine-3-17-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-ubuntu-22-04, build-7-2-ubuntu-22-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -3167,7 +3167,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-draft-release:
-    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-2-alpine-3-14, build-7-2-2-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-2-ubuntu-20-04, build-7-2-2-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
+    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-alpine-3-17, build-7-2-alpine-3-17-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-ubuntu-22-04, build-7-2-ubuntu-22-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -3182,7 +3182,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-dockerhub-description:
-    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-2-alpine-3-14, build-7-2-2-alpine-3-14-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-2-ubuntu-20-04, build-7-2-2-ubuntu-20-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
+    needs: [build-7-3-alpine-3-17, build-7-3-alpine-3-17-git-sops, build-7-2-alpine-3-17, build-7-2-alpine-3-17-git-sops, build-7-1-5-alpine-3-13, build-7-1-5-alpine-3-13-git-sops, build-7-0-3-alpine-3-9, build-7-0-3-alpine-3-9-git-sops, build-6-2-4-alpine-3-8, build-6-2-4-alpine-3-8-git-sops, build-6-1-3-alpine-3-8, build-6-1-3-alpine-3-8-git-sops, build-7-3-ubuntu-22-04, build-7-3-ubuntu-22-04-git-sops, build-7-2-ubuntu-22-04, build-7-2-ubuntu-22-04-git-sops, build-7-1-5-ubuntu-20-04, build-7-1-5-ubuntu-20-04-git-sops, build-7-0-3-ubuntu-18-04, build-7-0-3-ubuntu-18-04-git-sops, build-6-2-4-ubuntu-18-04, build-6-2-4-ubuntu-18-04-git-sops, build-6-1-3-ubuntu-18-04, build-6-1-3-ubuntu-18-04-git-sops, build-6-0-4-ubuntu-16-04, build-6-0-4-ubuntu-16-04-git-sops]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 |:-------:|:---------:|
 | `:7.3-alpine-3.17` | [View](variants/7.3-alpine-3.17) |
 | `:7.3-alpine-3.17-git-sops` | [View](variants/7.3-alpine-3.17-git-sops) |
-| `:7.2.2-alpine-3.14` | [View](variants/7.2.2-alpine-3.14) |
-| `:7.2.2-alpine-3.14-git-sops` | [View](variants/7.2.2-alpine-3.14-git-sops) |
+| `:7.2-alpine-3.17` | [View](variants/7.2-alpine-3.17) |
+| `:7.2-alpine-3.17-git-sops` | [View](variants/7.2-alpine-3.17-git-sops) |
 | `:7.1.5-alpine-3.13` | [View](variants/7.1.5-alpine-3.13) |
 | `:7.1.5-alpine-3.13-git-sops` | [View](variants/7.1.5-alpine-3.13-git-sops) |
 | `:7.0.3-alpine-3.9` | [View](variants/7.0.3-alpine-3.9) |
@@ -24,8 +24,8 @@ Dockerized `powershell`, based on [mcr.microsoft.com/powershell](https://hub.doc
 | `:6.1.3-alpine-3.8-git-sops` | [View](variants/6.1.3-alpine-3.8-git-sops) |
 | `:7.3-ubuntu-22.04`, `:latest` | [View](variants/7.3-ubuntu-22.04) |
 | `:7.3-ubuntu-22.04-git-sops` | [View](variants/7.3-ubuntu-22.04-git-sops) |
-| `:7.2.2-ubuntu-20.04` | [View](variants/7.2.2-ubuntu-20.04) |
-| `:7.2.2-ubuntu-20.04-git-sops` | [View](variants/7.2.2-ubuntu-20.04-git-sops) |
+| `:7.2-ubuntu-22.04` | [View](variants/7.2-ubuntu-22.04) |
+| `:7.2-ubuntu-22.04-git-sops` | [View](variants/7.2-ubuntu-22.04-git-sops) |
 | `:7.1.5-ubuntu-20.04` | [View](variants/7.1.5-ubuntu-20.04) |
 | `:7.1.5-ubuntu-20.04-git-sops` | [View](variants/7.1.5-ubuntu-20.04-git-sops) |
 | `:7.0.3-ubuntu-18.04` | [View](variants/7.0.3-ubuntu-18.04) |

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -1,14 +1,14 @@
 # Docker image variants' definitions
 $local:BASE_IMAGE_TAGS = @(
     '7.3-alpine-3.17'
-    '7.2.2-alpine-3.14-20220318'
+    'lts-7.2-alpine-3.17'
     '7.1.5-alpine-3.13-20211021'
     '7.0.3-alpine-3.9-20200928'
     '6.2.4-alpine-3.8'
     '6.1.3-alpine-3.8'
 
     '7.3-ubuntu-22.04'
-    '7.2.2-ubuntu-20.04-20220318'
+    'lts-7.2-ubuntu-22.04'
     '7.1.5-ubuntu-20.04-20211021'
     '7.0.3-ubuntu-18.04-20201027'
     '6.2.4-ubuntu-18.04'
@@ -37,9 +37,9 @@ $VARIANTS = @(
                     platforms =  'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x'
                     components = $subVariant['components']
                 }
-                # Docker image tag. E.g. '6.1.0-alpine-3.8', '6.1.0-alpine-3.8-git',
+                # Docker image tag. E.g. '7.1.5-alpine-3.13'
                 tag = @(
-                    $variant['base_image_tag'] -replace '-\d{8}', ''
+                    $variant['base_image_tag'] -replace '^lts-', '' -replace '-\d{8}$', '' # Replace 'lts-' prefix and 8-digit calver suffix
                     $subVariant['components'] | ? { $_ }
                 ) -join '-'
                 tag_as_latest = if ($variant['base_image_tag'] -eq $local:BASE_IMAGE_TAG_LATEST_STABLE -and $subVariant['components'].Count -eq 0) { $true } else { $false }

--- a/variants/7.2-alpine-3.17-git-sops/Dockerfile
+++ b/variants/7.2-alpine-3.17-git-sops/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/powershell:lts-7.2-alpine-3.17
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -Force -ErrorAction Stop -Verbose'
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 5.0.0 -Force -ErrorAction Stop -Verbose'
+
+RUN apk add --no-cache git
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.2-alpine-3.17-git-sops/docker-entrypoint.sh
+++ b/variants/7.2-alpine-3.17-git-sops/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- pwsh "$@"
+fi
+
+exec "$@"

--- a/variants/7.2-alpine-3.17/Dockerfile
+++ b/variants/7.2-alpine-3.17/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/powershell:lts-7.2-alpine-3.17
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -Force -ErrorAction Stop -Verbose'
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 5.0.0 -Force -ErrorAction Stop -Verbose'
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.2-alpine-3.17/docker-entrypoint.sh
+++ b/variants/7.2-alpine-3.17/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- pwsh "$@"
+fi
+
+exec "$@"

--- a/variants/7.2-ubuntu-22.04-git-sops/Dockerfile
+++ b/variants/7.2-ubuntu-22.04-git-sops/Dockerfile
@@ -1,0 +1,44 @@
+FROM mcr.microsoft.com/powershell:lts-7.2-ubuntu-22.04
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -Force -ErrorAction Stop -Verbose'
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 5.0.0 -Force -ErrorAction Stop -Verbose'
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y git; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install sops
+RUN set -eux; \
+    buildDeps="wget"; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y $buildDeps; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version; \
+    apt-get purge --auto-remove -y $buildDeps; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Install gnupg for sops
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y gnupg2; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.2-ubuntu-22.04-git-sops/docker-entrypoint.sh
+++ b/variants/7.2-ubuntu-22.04-git-sops/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- pwsh "$@"
+fi
+
+exec "$@"

--- a/variants/7.2-ubuntu-22.04/Dockerfile
+++ b/variants/7.2-ubuntu-22.04/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/powershell:lts-7.2-ubuntu-22.04
+
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+
+# Install Pester
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -Force -ErrorAction Stop -Verbose'
+RUN pwsh -c 'Install-Module Pester -Scope AllUsers -MinimumVersion 5.0.0 -Force -ErrorAction Stop -Verbose'
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.2-ubuntu-22.04/docker-entrypoint.sh
+++ b/variants/7.2-ubuntu-22.04/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- pwsh "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Since powershell >= 7.2.2, Microsoft no longer provides patch-specific docker image tags, but uses mutating minor tag with a `lts-` prefix for patch images.

Hence, the tag used for powershell >= 7.2 of our images follows suit: No more patch-version-specific image but a mutating minor tag.
